### PR TITLE
Upgrade InfluxDB to 2.4.0; base image to 6.1.2

### DIFF
--- a/influxdb2/CHANGELOG.md
+++ b/influxdb2/CHANGELOG.md
@@ -1,20 +1,9 @@
-## What’s changed - Release v1.0.2
+## What’s changed - Release v2.7.0-alpha.1
 
 ## 🚀 Enhancements
 
-- Nill
+- Upgrade to InfluxDB 2.7.0
 
-## 🧰 Maintenance
+## ⬆️ Dependency upgrades
 
-- Changes to default SSL behaviour on new deployments of the add-on.
-  New value: SSL = FALSE
-
-## ⬆️ Dependency updates
-
-- Nill
-
-## 📖 Full v1 Branch Changes
-
-- v1.0.2 = Changes to default SSL behaviour on new deployments of the add-on.
-- v1.0.1 - Release including updates to compatibility as InfluxDB only releases a AMD64 and ARM64 .deb file
-- V1.0.0 - Initial Release
+- Upgrade base image to 6.2.7

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -29,7 +29,9 @@ RUN \
         /var/lib/apt/lists/* \
     \
     && mkdir -p /data/influxdb2/engine \
-    && chmod +x /etc/cont-init.d/influxdb.sh
+    && chmod +x /etc/cont-init.d/influxdb.sh \
+    && chmod +x /etc/services.d/influxdb/run \
+    && chmod +x /etc/services.d/influxdb/finish \
 
 
 # Build arguments

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     && mkdir -p /data/influxdb2/engine \
     && chmod +x /etc/cont-init.d/influxdb.sh \
     && chmod +x /etc/services.d/influxdb/run \
-    && chmod +x /etc/services.d/influxdb/finish \
+    && chmod +x /etc/services.d/influxdb/finish
 
 
 # Build arguments

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:5.2.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.1.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -13,7 +13,7 @@ RUN \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
-    && INFLUXDB="2.1.1" \
+    && INFLUXDB="2.4.0" \
     && curl -J -L -o /tmp/influxdb2.deb \
         "https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB}-${ARCH}.deb" \
     \

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -8,6 +8,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 
+# Copy root filesystem
+COPY rootfs /
+
 RUN \
     export DEBIAN_FRONTEND=noninteractive \
     && apt update \
@@ -25,11 +28,9 @@ RUN \
         /var/{cache,log}/* \
         /var/lib/apt/lists/* \
     \
-    && mkdir -p /data/influxdb2/engine
+    && mkdir -p /data/influxdb2/engine \
+    && chmod +x /etc/cont-init.d/influxdb.sh
 
-
-# Copy root filesystem
-COPY rootfs /
 
 # Build arguments
 ARG BUILD_ARCH

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.1.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.2.7
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -9,11 +9,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG BUILD_ARCH=amd64
 
 RUN \
-    apt-get update \
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
-    && INFLUXDB="2.4.0" \
+    && INFLUXDB="2.7.0" \
     && curl -J -L -o /tmp/influxdb2.deb \
         "https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB}-${ARCH}.deb" \
     \
@@ -46,13 +47,13 @@ LABEL \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
     io.hass.version=${BUILD_VERSION} \
-    maintainer="Jay Antoney <jayantoney@gmail.com>" \
+    maintainer="Aaron Carson <aaron@aaroncarson.co.uk>" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.vendor="Jays Home Assistant Add-ons" \
-    org.opencontainers.image.authors="Jay Antoney <jayantoney@gmail.com>" \
+    org.opencontainers.image.vendor="aaroncarson's Home Assistant addons" \
+    org.opencontainers.image.authors="Aaron Carson <aaron@aaroncarson.co.uk>" \
     org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.url="https://github.com/Jays-Home-Assistant-Add-ons" \
+    org.opencontainers.image.url="https://github.com/caraar12345" \
     org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
     org.opencontainers.image.created=${BUILD_DATE} \

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -19,7 +19,7 @@ RUN \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
-    && curl -J -L -o /tmp/influxdb2.deb \
+    && curl -J -L -v -o /tmp/influxdb2.deb \
         "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB}/influxdb2_${INFLUXDB}-1_${ARCH}.deb" \
     \
     && dpkg --install /tmp/influxdb2.deb \
@@ -33,7 +33,6 @@ RUN \
     && chmod +x /etc/cont-init.d/influxdb.sh \
     && chmod +x /etc/services.d/influxdb/run \
     && chmod +x /etc/services.d/influxdb/finish
-
 
 # Build arguments
 ARG BUILD_ARCH

--- a/influxdb2/Dockerfile
+++ b/influxdb2/Dockerfile
@@ -1,4 +1,5 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:6.2.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:7.8.3
+ARG INFLUXDB=2.7.12
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -14,12 +15,12 @@ COPY rootfs /
 RUN \
     export DEBIAN_FRONTEND=noninteractive \
     && apt update \
+    && apt upgrade -y \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     \
-    && INFLUXDB="2.7.0" \
     && curl -J -L -o /tmp/influxdb2.deb \
-        "https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB}-${ARCH}.deb" \
+        "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB}/influxdb2_${INFLUXDB}-1_${ARCH}.deb" \
     \
     && dpkg --install /tmp/influxdb2.deb \
     \

--- a/influxdb2/build.yaml
+++ b/influxdb2/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.2.2
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.2.2
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.2.2
-  i386: ghcr.io/hassio-addons/debian-base/i386:5.2.2
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.2.7
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.2.7
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.2.7
+  i386: ghcr.io/hassio-addons/debian-base/i386:6.2.7

--- a/influxdb2/build.yaml
+++ b/influxdb2/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.2.7
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.2.7
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.2.7
-  i386: ghcr.io/hassio-addons/debian-base/i386:6.2.7
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.8.3
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.8.3
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:7.8.3
+  i386: ghcr.io/hassio-addons/debian-base/i386:7.8.3

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 2.7.0-alpha.2
+version: 2.7.0-alpha.3
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 2.7.0-alpha.1
+version: 2.7.0-alpha.2
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,9 +1,9 @@
 ---
 name: InfluxDB2
-version: 1.1.0
+version: 2.7.0-alpha.1
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
-url: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2
+url: https://github.com/caraar12345/ha-addon-influxdb2
 panel_icon: mdi:chart-areaspline
 startup: services
 homeassistant: 0.92.0b2
@@ -18,7 +18,7 @@ map:
 ports:
   8086/tcp: 8086
 ports_description:
-  8086/tcp: InfluxDB server
+  8086/tcp: InfluxDB
 options:
   reporting: true
   ssl: false

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 1.0.2
+version: 1.1.0
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/Jays-Home-Assistant-Add-ons/j-addon-influxdb2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -4,6 +4,7 @@ version: 2.7.0-alpha.1
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2
+image: aaroncarson/ha-addon-influxdb2
 panel_icon: mdi:chart-areaspline
 startup: services
 homeassistant: 0.92.0b2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 2.7.12-1
+version: 2.7.12-alpha.0
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 2.7.0-alpha.3
+version: 2.7.12-2
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2

--- a/influxdb2/config.yaml
+++ b/influxdb2/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: InfluxDB2
-version: 2.7.12-2
+version: 2.7.12-1
 slug: influxdb2
 description: Scalable datastore for metrics, events, and real-time analytics. Running InfluxDB v2.x.
 url: https://github.com/caraar12345/ha-addon-influxdb2


### PR DESCRIPTION
Neither InfluxDB nor the add-on base image have been updated in nearly a year. This gets both up to date!